### PR TITLE
Added handling for Magician's Magic Guard skill

### DIFF
--- a/src/main/java/com/dori/SpringStory/connection/packet/handlers/UserHandler.java
+++ b/src/main/java/com/dori/SpringStory/connection/packet/handlers/UserHandler.java
@@ -12,6 +12,8 @@ import com.dori.SpringStory.connection.packet.packets.CUserRemote;
 import com.dori.SpringStory.connection.packet.packets.CWvsContext;
 import com.dori.SpringStory.enums.*;
 import com.dori.SpringStory.jobs.handlers.WarriorHandler;
+import com.dori.SpringStory.temporaryStats.characters.CharacterTemporaryStat;
+import com.dori.SpringStory.utils.FormulaCalcUtils;
 import com.dori.SpringStory.utils.JobUtils;
 import com.dori.SpringStory.utils.SkillUtils;
 import com.dori.SpringStory.utils.utilEntities.Position;
@@ -116,6 +118,21 @@ public class UserHandler {
             if (divineShield != null && divineShield.getCurrentLevel() > 0) {
                 SkillData skillData = SkillDataHandler.getSkillDataByID(PALADIN_DIVINE_SHIELD.getId());
                 WarriorHandler.getInstance().handleSkill(chr, skillData, divineShield.getCurrentLevel());
+            }
+        }
+        if (JobUtils.isMagician(chr.getJob())) {
+            Skill magicGuard = chr.getSkill(MAGICIAN_MAGIC_GUARD.getId());
+            if (magicGuard != null && magicGuard.getCurrentLevel() > 0 && chr.getTsm().getCTS(CharacterTemporaryStat.MagicGuard) > 0) {
+                SkillData skillData = SkillDataHandler.getSkillDataByID(MAGICIAN_MAGIC_GUARD.getId());
+                float mpToReducePercent = FormulaCalcUtils.calcValueFromFormula(skillData.getSkillStatInfo().get(SkillStat.x), magicGuard.getCurrentLevel()) / 100.0f;
+                int mpToReduce = (int)(dmg * mpToReducePercent);
+                chr.modifyMp(-mpToReduce);
+
+                // If the characters MP is above 0 after taking the hit, then the damage dealt to their HP is reduced
+                // If the hit takes the player to 0 MP, then HP takes a full hit (as per the skill desc)
+                if (chr.getMp() > 0) {
+                    dmg = (int) (dmg * (1.0f - mpToReducePercent));
+                }
             }
         }
         chr.modifyHp(-dmg);

--- a/src/main/java/com/dori/SpringStory/temporaryStats/characters/BuffsDataLoader.java
+++ b/src/main/java/com/dori/SpringStory/temporaryStats/characters/BuffsDataLoader.java
@@ -77,6 +77,8 @@ public interface BuffsDataLoader {
         // Dragon Knight
         add(Job.DragonKnight, DRAGONKNIGHT_DRAGON_BLOOD, DragonBlood, "100 - 3 * x", "10 * x", 1, true);
         add(Job.DragonKnight, DRAGONKNIGHT_DRAGON_BLOOD, Pad, "5 + x", "10 * x");
+        // Magician
+        add(Job.Magician, MAGICIAN_MAGIC_GUARD, MagicGuard, "5 + 5 * x", "75 +35 * x");
         // Rogue
         add(Job.Thief, ROGUE_DARK_SIGHT, DarkSight, "1", "20 * x");
         // Assassin


### PR DESCRIPTION
- Reduces the damage the characters HP takes by '1 - X'% .
- Reduces the damage the characters MP takes by 'X'%.
- If the characters MP reduces to 0, their HP will take a full hit
- Checked to make sure this only works while the buff is active