### PR TITLE
adding vac, fixed melee attack for reactor and fixed broadcast handling for except char

### DIFF
--- a/src/main/java/com/dori/SpringStory/client/character/attack/AttackInfo.java
+++ b/src/main/java/com/dori/SpringStory/client/character/attack/AttackInfo.java
@@ -40,6 +40,10 @@ public class AttackInfo {
     public void decode(AttackType type, InPacket inPacket) {
         // FieldKey -
         this.fieldKey = inPacket.decodeByte();
+        // Reactor Melee attack extra handling -
+        if (type == AttackType.Melee && inPacket.getUnreadAmount() == 60) {
+            inPacket.decodeByte(); // Reactors extra byte
+        }
         // Type -
         this.type = type;
 

--- a/src/main/java/com/dori/SpringStory/client/commands/AdminCommands.java
+++ b/src/main/java/com/dori/SpringStory/client/commands/AdminCommands.java
@@ -13,6 +13,7 @@ import com.dori.SpringStory.services.StringDataService;
 import com.dori.SpringStory.temporaryStats.characters.BuffDataHandler;
 import com.dori.SpringStory.utils.MapleUtils;
 import com.dori.SpringStory.utils.utilEntities.Position;
+import com.dori.SpringStory.world.fieldEntities.Drop;
 import com.dori.SpringStory.world.fieldEntities.Field;
 import com.dori.SpringStory.world.fieldEntities.Portal;
 import com.dori.SpringStory.dataHandlers.ItemDataHandler;
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.dori.SpringStory.constants.GameConstants.MAX_MESO;
 import static com.dori.SpringStory.enums.InventoryOperation.Add;
@@ -362,10 +364,6 @@ public class AdminCommands {
 //                chr.write(CField.adminResult(cmdTypeFlag, false));
 //            }
         }
-        Position pos = new Position(chr.getPosition());
-        pos.setX(pos.getX() + 10);
-        pos.setY(pos.getY() + 10);
-        chr.write(CTownPortalPool.townPortalCreated(chr.getId(), true, pos));
     }
 
     @Command(names = {"invdata"}, requiredPermission = AccountType.GameMaster)
@@ -403,5 +401,16 @@ public class AdminCommands {
                 itemsToRemove.clear();
             }
         }
+    }
+
+    @Command(names = {"vac", "cleardrops", "clearDrops"}, requiredPermission = AccountType.GameMaster)
+    public static void vac(MapleChar chr, List<String> args) {
+        Field field = chr.getField();
+        field.getDrops().values().removeIf(drop -> {
+            field.removeDrop(drop.getId(), chr.getId(), 0);
+            chr.pickupItem(drop);
+            return true;
+        });
+        field.getDrops().clear();
     }
 }

--- a/src/main/java/com/dori/SpringStory/connection/netty/PacketEncoder.java
+++ b/src/main/java/com/dori/SpringStory/connection/netty/PacketEncoder.java
@@ -20,6 +20,7 @@ import static com.dori.SpringStory.constants.ServerConstants.ENABLE_ENCRYPTION;
  * packets is possible.
  *
  * @author Zygon
+ * @author Joo
  * @author Dori.
  */
 public final class PacketEncoder extends MessageToByteEncoder<OutPacket> {

--- a/src/main/java/com/dori/SpringStory/world/fieldEntities/Field.java
+++ b/src/main/java/com/dori/SpringStory/world/fieldEntities/Field.java
@@ -274,7 +274,7 @@ public class Field extends MapData {
             getPlayers().values().forEach(
                     chr -> {
                         if (chr.getId() != exceptChr.getId()) {
-                            chr.write(outPacket);
+                            chr.write((OutPacket) outPacket.clone());
                         }
                     }
             );


### PR DESCRIPTION
Changes -
- In `CUserLocal::TryDoingNormalAttack` handling need to either nop the extra decode or handle serverSide the extra decode that occur when trying to hit an reactor (need to check size is 60 in v95).
- Fixed the missed broadcast packet buffer copy to work as intended (Thanks @arnah  for noticing it!).
- Added Vac command (cuz everyone loves having vac :kekw: )
