### PR TITLE
Use byte buffer for packets to avoid copying

### DIFF
--- a/src/main/java/com/dori/SpringStory/connection/crypto/ShandaCipher.java
+++ b/src/main/java/com/dori/SpringStory/connection/crypto/ShandaCipher.java
@@ -6,8 +6,8 @@ import io.netty.buffer.ByteBuf;
 public interface ShandaCipher {
 
     static void encryptData(ByteBuf buf,
+                            int offset,
                             int length) {
-        int offset = 0;
         for (int j = 0; j < 6; j++) {
             byte remember = 0;
             byte dataLength = (byte) (length & 0xFF);
@@ -43,8 +43,8 @@ public interface ShandaCipher {
     }
 
     static void decryptData(ByteBuf buf,
+                            int offset,
                             int length) {
-        int offset = 0;
         for (int j = 1; j <= 6; j++) {
             byte remember = 0;
             byte dataLength = (byte) (length & 0xFF);

--- a/src/main/java/com/dori/SpringStory/connection/netty/LoginAcceptor.java
+++ b/src/main/java/com/dori/SpringStory/connection/netty/LoginAcceptor.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import static com.dori.SpringStory.constants.ServerConstants.LOGIN_PORT;
 
 // Taken from http://netty.io/wiki/user-guide-for-4.x.html
-public class LoginAcceptor implements Runnable{
+public class LoginAcceptor implements Runnable {
     // Channel pool -
     public static Map<String, Channel> channelPool = new HashMap<>();
     // Logger -

--- a/src/main/java/com/dori/SpringStory/connection/netty/NettyClient.java
+++ b/src/main/java/com/dori/SpringStory/connection/netty/NettyClient.java
@@ -54,12 +54,6 @@ public class NettyClient {
     protected final Channel ch;
     
     /**
-     * Lock regarding the encoding of packets to be sent to remote 
-     * sessions.
-     */
-    private final ReentrantLock lock;
-    
-    /**
      * InPacket object for this specific session since this can help
      * scaling compared to keeping OutPacket for each session.
      */
@@ -68,7 +62,6 @@ public class NettyClient {
     public NettyClient() {
         ch = null;
         r = new InPacket();
-        lock = new ReentrantLock(true); // note: lock is fair to ensure logical sequence is maintained server-side
     }
 
     /**
@@ -79,7 +72,6 @@ public class NettyClient {
     public NettyClient(Channel c) {
         ch = c;
         r = new InPacket();
-        lock = new ReentrantLock(true); // note: lock is fair to ensure logical sequence is maintained server-side
     }
     
     /**
@@ -130,22 +122,5 @@ public class NettyClient {
      */
     public String getIP() {
         return ch.remoteAddress().toString().split(":")[0].substring(1);
-    }
-    
-    /**
-     * Acquires the encoding state for this specific send IV. This is to
-     * prevent multiple encoding states to be possible at the same time. If 
-     * allowed, the send IV would mutate to an unusable IV and the session would
-     * be dropped as a result.
-     */
-    public final void acquireEncoderState() {
-        lock.lock();
-    }
-    
-    /**
-     * Releases the encoding state for this specific send IV.
-     */
-    public final void releaseEncodeState() {
-        lock.unlock();
     }
 }

--- a/src/main/java/com/dori/SpringStory/connection/netty/PacketDecoder.java
+++ b/src/main/java/com/dori/SpringStory/connection/netty/PacketDecoder.java
@@ -1,5 +1,6 @@
 package com.dori.SpringStory.connection.netty;
 
+import com.dori.SpringStory.connection.crypto.InitializationVector;
 import com.dori.SpringStory.connection.crypto.ShandaCipher;
 import com.dori.SpringStory.connection.crypto.ShroomAESCipher;
 import com.dori.SpringStory.connection.packet.InPacket;
@@ -15,13 +16,17 @@ import static com.dori.SpringStory.constants.ServerConstants.ENABLE_ENCRYPTION;
 
 public class PacketDecoder extends ReplayingDecoder<Integer> {
     private static final Logger log = new Logger(PacketDecoder.class);
+
     public static final int MAX_PACKET_LEN = 2 * 4096;
 
     private final ShroomAESCipher receiveCypher;
 
+    public PacketDecoder(InitializationVector iv, short version) {
+        this(new ShroomAESCipher(iv, version));
+    }
+
     public PacketDecoder(ShroomAESCipher receiveCypher) {
         super(-1);
-
         this.receiveCypher = receiveCypher;
     }
 
@@ -41,7 +46,7 @@ public class PacketDecoder extends ReplayingDecoder<Integer> {
         this.checkpoint(-1);
         receiveCypher.crypt(pktBuf, 0, packetLength);
         if (ENABLE_ENCRYPTION) {
-            ShandaCipher.decryptData(pktBuf, packetLength);
+            ShandaCipher.decryptData(pktBuf, 0, packetLength);
         }
         out.add(new InPacket(pktBuf));
     }

--- a/src/main/java/com/dori/SpringStory/connection/netty/PacketEncoder.java
+++ b/src/main/java/com/dori/SpringStory/connection/netty/PacketEncoder.java
@@ -1,5 +1,6 @@
 package com.dori.SpringStory.connection.netty;
 
+import com.dori.SpringStory.connection.crypto.InitializationVector;
 import com.dori.SpringStory.connection.crypto.ShandaCipher;
 import com.dori.SpringStory.connection.crypto.ShroomAESCipher;
 import com.dori.SpringStory.connection.packet.OutPacket;
@@ -12,6 +13,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.dori.SpringStory.constants.ServerConstants.ENABLE_ENCRYPTION;
 
@@ -26,46 +28,63 @@ import static com.dori.SpringStory.constants.ServerConstants.ENABLE_ENCRYPTION;
 public final class PacketEncoder extends MessageToByteEncoder<OutPacket> {
     private static final Logger logger = new Logger(PacketEncoder.class);
     private static final Map<Integer, OutHeader> outPacketHeaders = new HashMap<>();
-    private final ShroomAESCipher sendCypher;
+    private final ShroomAESCipher cipher;
+    private final ReentrantLock lock;
+    private boolean first;
+
+    public PacketEncoder(InitializationVector iv, short version) {
+        this(new ShroomAESCipher(iv, version));
+    }
 
     public PacketEncoder(ShroomAESCipher sendCypher) {
-        this.sendCypher = sendCypher;
+        this.cipher = sendCypher;
+        this.first = true;
+        this.lock = new ReentrantLock(true);
     }
 
     public static void initOutPacketOpcodesHandling() {
         Arrays.stream(OutHeader.values()).forEach(opcode -> outPacketHeaders.put(opcode.getValue(), opcode));
     }
 
+    void encodeToBuffer(OutPacket pkt, ByteBuf out) {
+        int len = pkt.getLength();
+        out.writeIntLE(cipher.encodeHeader(len));
+        int ix = out.writerIndex();
+        out.writeBytes(pkt.content());
+
+        // Encrypt shanda
+        if (ENABLE_ENCRYPTION) {
+            ShandaCipher.encryptData(out, ix, len);
+        }
+
+        // Encrypt aes
+        cipher.crypt(out, ix, len);
+    }
+
     @Override
-    protected void encode(ChannelHandlerContext chc, OutPacket outPacket, ByteBuf bb) {
+    protected void encode(ChannelHandlerContext chc, OutPacket pkt, ByteBuf out) {
         try {
-            ByteBuf bufferData = outPacket.getBufferData();
-            int len = bufferData.readableBytes();
-            NettyClient c = chc.channel().attr(NettyClient.CLIENT_KEY).get();
-            if (c != null) {
-                OutHeader outHeader = outPacketHeaders.get(outPacket.getHeader());
+            // Skip encryption for the first packet(Handshake)
+            if (!first) {
+                OutHeader outHeader = outPacketHeaders.get(pkt.getHeader());
                 if (!OutHeader.isSpamHeader(outHeader)) {
-                    logger.sent(String.valueOf(outPacket.getHeader()), "0x" + Integer.toHexString(outPacket.getHeader()).toUpperCase(), outHeader.name(), outPacket.toString());
+                    logger.sent(String.valueOf(pkt.getHeader()), "0x" + Integer.toHexString(pkt.getHeader()).toUpperCase(), outHeader.name(), pkt.toString());
                 }
-                bb.writeIntLE(sendCypher.encodeHeader(len));
-                if (ENABLE_ENCRYPTION) {
-                    ShandaCipher.encryptData(bufferData, len);
-                }
-                sendCypher.crypt(bufferData, 0, len);
-                c.acquireEncoderState();
+                this.lock.lock();
                 try {
-                    bb.writeBytes(bufferData);
+                    this.encodeToBuffer(pkt, out);
                 } finally {
-                    c.releaseEncodeState();
+                    this.lock.unlock();
                 }
             } else {
-                logger.debug("Plain sending packet: " + outPacket);
-                bb.writeBytes(bufferData);
+                logger.debug("Plain sending packet: " + pkt);
+                out.writeBytes(pkt.content());
+                this.first = false;
             }
         } catch (Exception e) {
             logger.error("Error occurred while parsing OutPacket!! ", e);
         } finally {
-            outPacket.release();
+            pkt.release();
         }
     }
 }

--- a/src/main/java/com/dori/SpringStory/connection/packet/InPacket.java
+++ b/src/main/java/com/dori/SpringStory/connection/packet/InPacket.java
@@ -36,23 +36,6 @@ public class InPacket extends Packet {
         this(Unpooled.copiedBuffer(data));
     }
 
-    @Override
-    public int getLength() {
-        return byteBuf.readableBytes();
-    }
-
-    @Override
-    public byte[] getData() {
-        byte[] bytes = new byte[byteBuf.readableBytes()];
-        byteBuf.duplicate().readBytes(bytes);
-        return bytes;
-    }
-
-    @Override
-    public InPacket clone() {
-        return new InPacket(byteBuf);
-    }
-
     /**
      * Reads a single byte of the ByteBuf.
      * @return The byte that has been read.
@@ -119,7 +102,8 @@ public class InPacket extends Packet {
 
     @Override
     public String toString() {
-        return MapleUtils.readableByteArray(Arrays.copyOfRange(getData(), getData().length - getUnreadAmount(), getData().length)); // Substring after copy of range xd
+        return super.toString();
+        //return MapleUtils.readableByteArray(Arrays.copyOfRange(getData(), getData().length - getUnreadAmount(), getData().length)); // Substring after copy of range xd
     }
 
 
@@ -163,10 +147,6 @@ public class InPacket extends Packet {
         return byteBuf.readableBytes();
     }
 
-    public void release() {
-        byteBuf.release();
-    }
-
     /**
      * Reads a rectangle (int l, int t, int r, int b) and returns this.
      * @return The rectangle that has been read.
@@ -176,6 +156,6 @@ public class InPacket extends Packet {
     }
 
     public boolean decodeBool(){
-        return decodeByte() > 0;
+        return decodeByte() != 0;
     }
 }

--- a/src/main/java/com/dori/SpringStory/connection/packet/OutPacket.java
+++ b/src/main/java/com/dori/SpringStory/connection/packet/OutPacket.java
@@ -9,10 +9,8 @@ import com.dori.SpringStory.utils.utilEntities.Rect;
 import io.netty.buffer.*;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 
 public class OutPacket extends Packet {
-    private ByteBuf baos;
     private boolean loopback = false;
     private boolean encryptedByShanda = false;
     private short op;
@@ -24,8 +22,7 @@ public class OutPacket extends Packet {
      * @param op The opcode of this OutPacket.
      */
     public OutPacket(short op) {
-        super(new byte[]{});
-        baos = Unpooled.buffer();
+        super(Unpooled.buffer());
         encodeShort(op);
         this.op = op;
     }
@@ -43,8 +40,7 @@ public class OutPacket extends Packet {
      * Creates a new OutPacket, and initializes the data as empty.
      */
     public OutPacket() {
-        super(new byte[]{});
-        baos = Unpooled.buffer();
+        super(Unpooled.buffer());
     }
 
     /**
@@ -53,10 +49,8 @@ public class OutPacket extends Packet {
      * @param data The data this net.swordie.ms.connection.packet has to be initialized with.
      */
     public OutPacket(byte[] data, short opcode) {
-        super(data);
+        super(Unpooled.wrappedBuffer(data));
         op = opcode;
-        baos = Unpooled.buffer();
-        encodeArr(data);
     }
 
     /**
@@ -66,6 +60,10 @@ public class OutPacket extends Packet {
      */
     public OutPacket(OutHeader header) {
         this(header.getValue());
+    }
+    
+    public InPacket toInPacket() {
+        return new InPacket(buf);
     }
 
     /**
@@ -93,7 +91,7 @@ public class OutPacket extends Packet {
      * @param b The byte to encode.
      */
     public void encodeByte(byte b) {
-        baos.writeByte(b);
+        buf.writeByte(b);
     }
 
     public void encodeBool(boolean bNext) {
@@ -107,7 +105,7 @@ public class OutPacket extends Packet {
      * @param bArr The byte array to encode.
      */
     public void encodeArr(byte[] bArr) {
-        baos.writeBytes(bArr);
+        this.buf.writeBytes(bArr);
     }
 
     /**
@@ -125,7 +123,7 @@ public class OutPacket extends Packet {
      * @param c The character to encode
      */
     public void encodeChar(char c) {
-        baos.writeByte(c);
+        buf.writeByte(c);
     }
 
     /**
@@ -134,7 +132,7 @@ public class OutPacket extends Packet {
      * @param b The boolean to encode (0/1)
      */
     public void encodeByte(boolean b) {
-        baos.writeBoolean(b);
+        buf.writeBoolean(b);
     }
 
     /**
@@ -143,15 +141,15 @@ public class OutPacket extends Packet {
      * @param s The short to encode.
      */
     public void encodeShort(short s) {
-        baos.writeShortLE(s);
+        buf.writeShortLE(s);
     }
 
     public void encodeShortBE(short s) {
-        baos.writeShort(s);
+        buf.writeShort(s);
     }
 
     public void encodeIntBE(int i) {
-        baos.writeInt(i);
+        buf.writeInt(i);
     }
 
     /**
@@ -160,7 +158,7 @@ public class OutPacket extends Packet {
      * @param i The integer to encode.
      */
     public void encodeInt(int i) {
-        baos.writeIntLE(i);
+        buf.writeIntLE(i);
     }
 
     /**
@@ -169,7 +167,7 @@ public class OutPacket extends Packet {
      * @param l The long to encode.
      */
     public void encodeLong(long l) {
-        baos.writeLongLE(l);
+        buf.writeLongLE(l);
     }
 
     /**
@@ -187,7 +185,7 @@ public class OutPacket extends Packet {
             return;
         }
         encodeShort((short) s.length());
-        baos.writeCharSequence(s, CHARSET);
+        buf.writeCharSequence(s, CHARSET);
     }
 
     /**
@@ -211,41 +209,6 @@ public class OutPacket extends Packet {
         }
     }
 
-    @Override
-    public void setData(byte[] nD) {
-        super.setData(nD);
-        baos.clear();
-        encodeArr(nD);
-    }
-
-    @Override
-    public byte[] getData() {
-        if (super.getLength() == 0) {
-            super.setData(ByteBufUtil.getBytes(baos));
-//            baos.release();
-        }
-        return super.getData();
-    }
-
-    public ByteBuf getBufferData() {
-        return this.baos;
-    }
-
-    @Override
-    public Packet clone() {
-        return new OutPacket(getData(), op);
-    }
-
-    /**
-     * Returns the length of the ByteArrayOutputStream.
-     *
-     * @return The length of baos.
-     */
-    @Override
-    public int getLength() {
-        return getData().length;
-    }
-
     public boolean isLoopback() {
         return loopback;
     }
@@ -256,7 +219,7 @@ public class OutPacket extends Packet {
 
     @Override
     public String toString() {
-        return MapleUtils.readableByteArray(Arrays.copyOfRange(getData(), 2, getData().length));
+        return super.toString();
     }
 
     public void encodeShort(int value) {
@@ -317,12 +280,5 @@ public class OutPacket extends Packet {
 
     public void encode(Encodable encodable) {
         encodable.encode(this);
-    }
-
-    @Override
-    public void release() {
-        super.release();
-        this.baos.release();
-        this.baos = null;
     }
 }

--- a/src/main/java/com/dori/SpringStory/connection/packet/Packet.java
+++ b/src/main/java/com/dori/SpringStory/connection/packet/Packet.java
@@ -17,8 +17,8 @@
 */
 package com.dori.SpringStory.connection.packet;
 
-import com.dori.SpringStory.utils.MapleUtils;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -29,54 +29,90 @@ import java.nio.charset.StandardCharsets;
  * functionality because it is a MapleStory packet.
  *
  */
-public class Packet implements Cloneable {
-
-    private byte[] data;
+public class Packet implements ByteBufHolder {
     protected static final Charset CHARSET = StandardCharsets.ISO_8859_1;
+    protected ByteBuf buf;
 
-    public Packet(byte[] data) {
-        this.data = new byte[data.length];
-        System.arraycopy(data, 0, this.data, 0, data.length);
-    }
-
-    public Packet(ByteBuf data) {
+    public Packet(ByteBuf buf) {
+        this.buf = buf;
         //this.data = new byte[data.readableBytes()];
         //System.arraycopy(data, 0, this.data, 0, data.length);
     }
 
     public int getLength() {
-        if (data != null) {
-            return data.length;
-        }
-        return 0;
+        return this.buf.readableBytes();
     }
 
     public int getHeader() {
-        if (data.length < 2) {
+        if (this.buf.readableBytes() < 2) {
             return 0xFFFF;
         }
-        return (data[0] + (data[1] << 8));
-    }
-
-    public void setData(byte[] nD) {
-        data = nD;
-    }
-
-    public byte[] getData() {
-        return data;
+        return this.buf.getShortLE(0);
     }
     
     @Override
     public String toString() {
-        if (data == null) return "";
-        return "[Pck] | " + MapleUtils.readableByteArray(data);
-    }
-    
-    @Override
-    public Packet clone() {
-        return new Packet(data);
+        return "[Pck] | " + this.buf.toString();
     }
 
-    public void release(){}
+    @Override
+    public int refCnt() {
+        return this.buf.refCnt();
+    }
+
+    @Override
+    public boolean release(int arg0) {
+        return this.buf.release(arg0);
+    }
+
+    @Override
+    public ByteBuf content() {
+        return this.buf;
+    }
+
+    @Override
+    public Packet copy() {
+        return new Packet(this.buf.copy());
+    }
+
+    @Override
+    public Packet duplicate() {
+        return new Packet(this.buf.duplicate());
+    }
+
+    @Override
+    public ByteBufHolder retainedDuplicate() {
+        return new Packet(this.buf.retainedDuplicate());
+    }
+
+    @Override
+    public ByteBufHolder replace(ByteBuf content) {
+        return new Packet(content);
+    }
+
+    @Override
+    public ByteBufHolder retain() {
+        return new Packet(this.buf.retain());
+    }
+
+    @Override
+    public ByteBufHolder retain(int increment) {
+        return new Packet(this.buf.retain(increment));
+    }
+
+    @Override
+    public ByteBufHolder touch() {      
+        return new Packet(this.buf.touch());
+    }
+
+    @Override
+    public ByteBufHolder touch(Object hint) {
+        return new Packet(this.buf.touch(hint));
+    }
+
+    @Override
+    public boolean release() {
+        return this.buf.release();
+    }
 
 }

--- a/src/main/java/com/dori/SpringStory/connection/packet/handlers/LoginHandler.java
+++ b/src/main/java/com/dori/SpringStory/connection/packet/handlers/LoginHandler.java
@@ -187,7 +187,7 @@ public class LoginHandler {
             outPacket.encodeString(AUTO_LOGIN_PASSWORD);
             outPacket.encodeArr(new byte[27]);
 
-            handleLoginPassword(c, new InPacket(outPacket.getData()));
+            handleLoginPassword(c, outPacket.toInPacket());
         }
     }
 }

--- a/src/main/java/com/dori/SpringStory/world/fieldEntities/Field.java
+++ b/src/main/java/com/dori/SpringStory/world/fieldEntities/Field.java
@@ -265,7 +265,7 @@ public class Field extends MapData {
     }
 
     public void broadcastPacket(OutPacket outPacket) {
-        getPlayers().values().forEach(chr -> chr.write((OutPacket) outPacket.clone()));
+        getPlayers().values().forEach(chr -> chr.write((OutPacket) outPacket.retainedDuplicate()));
     }
 
     public void broadcastPacket(OutPacket outPacket, MapleChar exceptChr) {
@@ -274,7 +274,7 @@ public class Field extends MapData {
             getPlayers().values().forEach(
                     chr -> {
                         if (chr.getId() != exceptChr.getId()) {
-                            chr.write((OutPacket) outPacket.clone());
+                            chr.write((OutPacket) outPacket.retainedDuplicate());
                         }
                     }
             );


### PR DESCRIPTION
Groundwork to use netty byte bufs for packets properly. Not done yet(!)

- [ ] Use `ByteBuf` in packet
- [ ] Make Packets basically immutable, after sending(maybe add a special type)
- [ ] Create a proper channel handler
- [ ] Test against live client
- [ ] Unit tests
- [ ] Ref Count Test